### PR TITLE
Allowing file paths with spaces

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ var getCommandLineOptionArgString = function(opts, files){
     }
     
     files.forEach(function(file) {
-        arg += " /path " + file;
+        arg += " /path \"" + file + "\"";
     }, this);
     
     return arg;


### PR DESCRIPTION
Hey @zpbappi, I was trying to use your plugin to run Chutzpah, and ran into an issue where my chutzpah.json file was in a Windows directory that contained a space.  This resulted in an error in the Gulp task, so I simply added quotes around the file path when constructing the argument string to the Chutzpah runner.

![gulp-chutzpah_error](https://cloud.githubusercontent.com/assets/6718499/12822767/334beb9a-cb2f-11e5-9044-9337d182e9f8.png)

Thanks for writing this plugin; it's been really helpful!
