### PR TITLE
settingsFileEnvironment has string

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var defaultOpts = {
     vsoutput: false,
     coverage: false,
     showFailureReport: false,
-    settingsFileEnvironment: false,
+    settingsFileEnvironment: "",
     junit: "",
     lcov: "",
     trx: "",


### PR DESCRIPTION
- settingsFileEnvironment is a boolean but Chutzpah takes a string. Since the type is different, this option is not added as a parameter to Chutzpah.
- The change consist of changing the default type to an empty string to have the option passed to Chutzpah command line parameter.
