### PR TITLE
new option "settingsFile" for issue 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,8 @@
 var gutil = require("gulp-util"),
     through = require("through2"),
     exec = require("child_process").exec,
-    shallowCopy = require("util")._extend;
+    shallowCopy = require("util")._extend,
+    Readable = require('stream').Readable;
 
 var defaultOpts = {
     nologo: false,
@@ -13,8 +14,8 @@ var defaultOpts = {
     failOnError: false,
     debug: false,
     trace: false,
-    openInBrowser: void(0),
-    parallelism: void(0),
+    openInBrowser: void (0),
+    parallelism: void (0),
     vsoutput: false,
     coverage: false,
     showFailureReport: false,
@@ -26,79 +27,120 @@ var defaultOpts = {
     coveragehtml: ""
 };
 
-var getCombinedOpts = function(baseOpts, userSuppliedOpts){
-    if(!userSuppliedOpts)
+var getCombinedOpts = function (baseOpts, userSuppliedOpts) {
+    if (!userSuppliedOpts)
         return baseOpts;
-        
+
     for (var key in userSuppliedOpts) {
-        if (isValidProperty(baseOpts, userSuppliedOpts, key)){
+        if (isValidProperty(baseOpts, userSuppliedOpts, key)) {
             baseOpts[key] = userSuppliedOpts[key];
         }
     }
-    
+
     return baseOpts;
 };
 
-var isValidProperty = function(baseOpts, userOpts, propertyName){
-    return  baseOpts.hasOwnProperty(propertyName) && 
-            userOpts.hasOwnProperty(propertyName) &&
-            (
-                typeof baseOpts[propertyName] === typeof userOpts[propertyName] ||
-                typeof baseOpts[propertyName] === "undefined" 
-            );
+var isValidProperty = function (baseOpts, userOpts, propertyName) {
+    return baseOpts.hasOwnProperty(propertyName) &&
+        userOpts.hasOwnProperty(propertyName) &&
+        (
+            typeof baseOpts[propertyName] === typeof userOpts[propertyName] ||
+            typeof baseOpts[propertyName] === "undefined"
+        );
 };
 
-var getCommandLineOptionArgString = function(opts, files){
+var getCommandLineOptionArgString = function (opts, files) {
     var arg = "";
     files = files || [];
 
     for (var key in opts) {
-        if (!opts.hasOwnProperty(key)) 
+        if (!opts.hasOwnProperty(key))
             continue;
-            
-        if(typeof opts[key] === "boolean")
+
+        if (typeof opts[key] === "boolean")
             arg += opts[key] ? " /" + key : "";
-        else if(typeof opts[key] === "string")
+        else if (typeof opts[key] === "string")
             arg += opts[key].length ? (" /" + key + " " + opts[key]) : "";
-        else if(typeof opts[key] === "number")
-            arg += " /" + key + " " + opts[key];                
+        else if (typeof opts[key] === "number")
+            arg += " /" + key + " " + opts[key];
     }
-    
-    files.forEach(function(file) {
+
+    files.forEach(function (file) {
         arg += " /path \"" + file + "\"";
     }, this);
-    
+
     return arg;
 };
 
-var chutzpahRunner = function(userOpts){
-    if(!userOpts || typeof userOpts["executable"] !== "string" || userOpts["executable"].length === 0){
+var getStream = function (opts, userOpts) {
+    var files = [];
+    return through.obj(
+        function (file, encoding, callback) {
+            if (!file.isNull())
+                files.push(file.path);
+
+            callback(null, file);
+        },
+        function (callback) {
+            var args = getCommandLineOptionArgString(opts, files),
+                command = userOpts.executable + args;
+
+            execCommand(command, callback);
+        }
+    );
+}
+
+var getNewStream = function (opts, userOpts) {
+    var stream = new Readable({ objectMode: true });
+    stream._read = function () { };
+
+    getSettingsFileCommandPromise(opts, userOpts)
+        .then(function () {
+            stream.emit('end');
+        }, function (e) {
+            var existingError = new Error(e);
+            var err = new gutil.PluginError("gulp-chutzpah", existingError);
+
+            stream.emit('error', err);
+            stream.emit('end');
+        });
+    return stream;
+}
+
+var getSettingsFileCommandPromise = function (opts, userOpts) {
+    return new Promise(function (resolve, reject) {
+        var args = getCommandLineOptionArgString(opts, []),
+            command = userOpts.executable + ' ' + userOpts.settingsFile + args;
+
+        execCommand(command, resolve);
+    });
+}
+
+var execCommand = function (command, callback) {
+    exec(command, function (err, stdout, stderr) {
+        console.log(stdout);
+        console.error(stderr);
+        callback(err);
+    });
+}
+
+var chutzpahRunner = function (userOpts) {
+    if (!userOpts || typeof userOpts["executable"] !== "string" || userOpts["executable"].length === 0) {
         throw new gutil.PluginError({
             plugin: "gulp-chutzpah",
             message: "gulp-chutzpah: path to chutzpah runner must be specified using the property named 'executable'."
         });
     }
-    
-    var files = [];
-    var opts = shallowCopy({}, defaultOpts); 
+
+    var opts = shallowCopy({}, defaultOpts);
     opts = getCombinedOpts(opts, userOpts);
-    
-    return through.obj(
-        function(file, encoding, callback){
-            if (!file.isNull())
-                files.push(file.path);
-    
-            callback(null, file);
-        },
-        function(callback){
-            var args = getCommandLineOptionArgString(opts, files);
-            exec(userOpts.executable + args, function(err, stdout, stderr){
-                console.log(stdout);
-                console.error(stderr);
-                callback(err);
-            });
-        }
-    );
+
+    if (userOpts.settingsFile) {
+        return getNewStream(opts, userOpts);
+    }
+    else {
+        return getStream(opts, userOpts);
+    }
 };
 
 module.exports = chutzpahRunner;

--- a/index.js
+++ b/index.js
@@ -3,8 +3,7 @@
 var gutil = require("gulp-util"),
     through = require("through2"),
     exec = require("child_process").exec,
-    shallowCopy = require("util")._extend,
-    Readable = require('stream').Readable;
+    shallowCopy = require("util")._extend;
 
 var defaultOpts = {
     nologo: false,
@@ -14,8 +13,8 @@ var defaultOpts = {
     failOnError: false,
     debug: false,
     trace: false,
-    openInBrowser: void (0),
-    parallelism: void (0),
+    openInBrowser: void(0),
+    parallelism: void(0),
     vsoutput: false,
     coverage: false,
     showFailureReport: false,
@@ -27,120 +26,94 @@ var defaultOpts = {
     coveragehtml: ""
 };
 
-var getCombinedOpts = function (baseOpts, userSuppliedOpts) {
-    if (!userSuppliedOpts)
+var getCombinedOpts = function(baseOpts, userSuppliedOpts){
+    if(!userSuppliedOpts)
         return baseOpts;
-
+        
     for (var key in userSuppliedOpts) {
-        if (isValidProperty(baseOpts, userSuppliedOpts, key)) {
+        if (isValidProperty(baseOpts, userSuppliedOpts, key)){
             baseOpts[key] = userSuppliedOpts[key];
         }
     }
-
+    
     return baseOpts;
 };
 
-var isValidProperty = function (baseOpts, userOpts, propertyName) {
-    return baseOpts.hasOwnProperty(propertyName) &&
-        userOpts.hasOwnProperty(propertyName) &&
-        (
-            typeof baseOpts[propertyName] === typeof userOpts[propertyName] ||
-            typeof baseOpts[propertyName] === "undefined"
-        );
+var isValidProperty = function(baseOpts, userOpts, propertyName){
+    return  baseOpts.hasOwnProperty(propertyName) && 
+            userOpts.hasOwnProperty(propertyName) &&
+            (
+                typeof baseOpts[propertyName] === typeof userOpts[propertyName] ||
+                typeof baseOpts[propertyName] === "undefined" 
+            );
 };
 
-var getCommandLineOptionArgString = function (opts, files) {
+var getCommandLineOptionArgString = function(opts, files, isSettingsFile){
     var arg = "";
     files = files || [];
 
+	validateSettingsFile(files, isSettingsFile);
+	
     for (var key in opts) {
-        if (!opts.hasOwnProperty(key))
+        if (!opts.hasOwnProperty(key)) 
             continue;
-
-        if (typeof opts[key] === "boolean")
+            
+        if(typeof opts[key] === "boolean")
             arg += opts[key] ? " /" + key : "";
-        else if (typeof opts[key] === "string")
+        else if(typeof opts[key] === "string")
             arg += opts[key].length ? (" /" + key + " " + opts[key]) : "";
-        else if (typeof opts[key] === "number")
-            arg += " /" + key + " " + opts[key];
+        else if(typeof opts[key] === "number")
+            arg += " /" + key + " " + opts[key];                
     }
-
-    files.forEach(function (file) {
-        arg += " /path \"" + file + "\"";
-    }, this);
-
+    
+    if (isSettingsFile) {
+        arg = ' ' + files[0] + arg;
+    } else {
+        files.forEach(function(file) {
+            arg += " /path \"" + file + "\"";
+        }, this);
+    }
+    
     return arg;
 };
 
-var getStream = function (opts, userOpts) {
-    var files = [];
-    return through.obj(
-        function (file, encoding, callback) {
-            if (!file.isNull())
-                files.push(file.path);
+var validateSettingsFile = function(files, isSettingsFile){
+	if(isSettingsFile && (files.length !== 1 || !files[0].endsWith('.json'))){
+		throw new gutil.PluginError({
+			plugin: "gulp-chutzpah",
+			message: "gulp-chutzpah: invalid chutzpah.json settings file specified in the source stream."
+		});
+    }
+};
 
-            callback(null, file);
-        },
-        function (callback) {
-            var args = getCommandLineOptionArgString(opts, files),
-                command = userOpts.executable + args;
-
-            execCommand(command, callback);
-        }
-    );
-}
-
-var getNewStream = function (opts, userOpts) {
-    var stream = new Readable({ objectMode: true });
-    stream._read = function () { };
-
-    getSettingsFileCommandPromise(opts, userOpts)
-        .then(function () {
-            stream.emit('end');
-        }, function (e) {
-            var existingError = new Error(e);
-            var err = new gutil.PluginError("gulp-chutzpah", existingError);
-
-            stream.emit('error', err);
-            stream.emit('end');
-        });
-    return stream;
-}
-
-var getSettingsFileCommandPromise = function (opts, userOpts) {
-    return new Promise(function (resolve, reject) {
-        var args = getCommandLineOptionArgString(opts, []),
-            command = userOpts.executable + ' ' + userOpts.settingsFile + args;
-
-        execCommand(command, resolve);
-    });
-}
-
-var execCommand = function (command, callback) {
-    exec(command, function (err, stdout, stderr) {
-        console.log(stdout);
-        console.error(stderr);
-        callback(err);
-    });
-}
-
-var chutzpahRunner = function (userOpts) {
-    if (!userOpts || typeof userOpts["executable"] !== "string" || userOpts["executable"].length === 0) {
+var chutzpahRunner = function(userOpts){
+    if(!userOpts || typeof userOpts["executable"] !== "string" || userOpts["executable"].length === 0){
         throw new gutil.PluginError({
             plugin: "gulp-chutzpah",
             message: "gulp-chutzpah: path to chutzpah runner must be specified using the property named 'executable'."
         });
     }
-
-    var opts = shallowCopy({}, defaultOpts);
+    
+    var files = [];
+    var opts = shallowCopy({}, defaultOpts); 
     opts = getCombinedOpts(opts, userOpts);
-
-    if (userOpts.settingsFile) {
-        return getNewStream(opts, userOpts);
-    }
-    else {
-        return getStream(opts, userOpts);
-    }
+    
+    return through.obj(
+        function(file, encoding, callback){
+            if (!file.isNull())
+                files.push(file.path);
+    
+            callback(null, file);
+        },
+        function(callback){
+            var args = getCommandLineOptionArgString(opts, files, userOpts.isSettingsFile);
+            exec(userOpts.executable + args, function(err, stdout, stderr){
+                console.log(stdout);
+                console.error(stderr);
+                callback(err);
+            });
+        }
+    );
 };
 
 module.exports = chutzpahRunner;


### PR DESCRIPTION
Hi! I have added a new parameter "settingsFile" to the plugin options where you can specify the path of a chutzpah.json setting file. 

Inside the chutzpah.json you can set a "Tests" property with the test files that must be executed. It accepts globs too.

With this pull request, the [issue](https://github.com/zpbappi/gulp-chutzpah/issues/4) is fixed.

You can check the following official links:
[https://github.com/mmanela/chutzpah/wiki/Chutzpah.json-Settings-File](https://github.com/mmanela/chutzpah/wiki/Chutzpah.json-Settings-File)
[https://github.com/mmanela/chutzpah/wiki/Tests-setting](https://github.com/mmanela/chutzpah/wiki/Tests-setting)

If you use this new parameter, the plugin can be invoked without a "pipe" or a previous "gulp.src".